### PR TITLE
Don't require illuminate/support 4.1 specifically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.*",
+        "illuminate/support": "4.*",
         "twig/twig": "1.*",
         "michelf/php-markdown": "1.4.*"
     },


### PR DESCRIPTION
It was quite annoying when trying to update to laravel 4.2
