### PR TITLE
TwigBridge 0.6 support

### DIFF
--- a/src/Lablog/Markdown/MarkdownServiceProvider.php
+++ b/src/Lablog/Markdown/MarkdownServiceProvider.php
@@ -22,7 +22,17 @@ class MarkdownServiceProvider extends ServiceProvider {
 
 		$twig = \Config::get('twigbridge::extensions');
 
-		$twig[] = 'Lablog\Markdown\Twig\MarkdownLoader';
+		$class = 'Lablog\Markdown\Twig\MarkdownLoader';
+		if (isset($twig['enabled']))
+		{
+			/* TwigBridge 0.6 */
+			$twig['enabled'][] = $class;
+		}
+		else
+		{
+			/* TwigBridge 0.5 */
+			$twig[] = $class;
+		}
 
 		\Config::set('twigbridge::extensions', $twig);
 	}


### PR DESCRIPTION
This extension has almost no code and it managed to break anyway

The config structure changed, extensions need to be added to the 'enabled' list. This commit checks if that array exists and if so, adds it there. Still compatible with twigbridge 0.5. 

This isn't _really_ needed - 'Lablog\Markdown\Twig\MarkdownLoader' could be added to the twigbridge config manually, getting the same effect, but whatever. 
